### PR TITLE
Updated to use libcxx instead of stdlib template

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,9 @@ about:
     dev_url: https://github.com/ianlancetaylor/libbacktrace
     doc_url: https://github.com/ianlancetaylor/libbacktrace
     summary: A C library that may be linked into a C/C++ program to produce symbolic backtraces
+    description: |
+        Libbacktrace is a lightweight C library for generating symbolic backtraces in C/C++ apps. 
+        It supports various executable formats with DWARF debugging and is ideal for error reporting and profiling.
     license: BSD-3-Clause
     license_file: LICENSE
     license_family: BSD

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,9 +31,11 @@ test:
 
 about:
     home: https://github.com/ianlancetaylor/libbacktrace
-    license: BSD-3-Clause
+    dev_url: https://github.com/ianlancetaylor/libbacktrace
+    doc_url: https://github.com/ianlancetaylor/libbacktrace
     summary: A C library that may be linked into a C/C++ program to produce symbolic backtraces
     license_file: LICENSE
+    license_family: BSD-3-Clause
 
 extra:
     recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - libcxx     # [osx]
         - make       # [unix]
     host:
-        - zlib
+        - zlib {{ zlib }}
 
 test:
     commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
     build:
         - {{ compiler('c') }}
-        - {{ stdlib("c") }}
+        - libcxx     # [osx]
         - make       # [unix]
     host:
         - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,9 @@ about:
     dev_url: https://github.com/ianlancetaylor/libbacktrace
     doc_url: https://github.com/ianlancetaylor/libbacktrace
     summary: A C library that may be linked into a C/C++ program to produce symbolic backtraces
+    license: BSD-3-Clause
     license_file: LICENSE
-    license_family: BSD-3-Clause
+    license_family: BSD
 
 extra:
     recipe-maintainers:


### PR DESCRIPTION
backtrace 20241216

**Destination channel:** defaults

### Links

- [PKG-7237](https://anaconda.atlassian.net/browse/PKG-7237) 
- [Upstream repository](https://github.com/ianlancetaylor/libbacktrace)
- Relevant dependency PRs:

### Explanation of changes:
- modified for Anaconda builds


[PKG-7237]: https://anaconda.atlassian.net/browse/PKG-7237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ